### PR TITLE
feature: enhance destroy command

### DIFF
--- a/exec/executor.go
+++ b/exec/executor.go
@@ -38,6 +38,12 @@ type BaseDockerClientExecutor struct {
 // commonFunc is the command created function
 var commonFunc = func(uid string, ctx context.Context, model *spec.ExpModel) string {
 	if suid, ok := spec.IsDestroy(ctx); ok {
+		if suid == spec.UnknownUid {
+			matchers := spec.ConvertExpMatchersToString(model, func() map[string]spec.Empty {
+				return GetAllDockerFlagNames()
+			})
+			return fmt.Sprintf("%s destroy %s %s %s", BladeBin, model.Target, model.ActionName, matchers)
+		}
 		return fmt.Sprintf("%s destroy %s", BladeBin, suid)
 	} else {
 		matchers := spec.ConvertExpMatchersToString(model, func() map[string]spec.Empty {

--- a/exec/model.go
+++ b/exec/model.go
@@ -121,10 +121,11 @@ func extractExecutorFromExpModel(expModel spec.ExpModelCommandSpec) map[string]s
 }
 
 var ContainerIdFlag = &spec.ExpFlag{
-	Name:     "container-id",
-	Desc:     "Container id",
-	NoArgs:   false,
-	Required: false,
+	Name:                  "container-id",
+	Desc:                  "Container id",
+	NoArgs:                false,
+	Required:              false,
+	RequiredWhenDestroyed: true,
 }
 
 var ImageRepoFlag = &spec.ExpFlag{


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
See chaosblade-io/chaosblade#239 for the details.

### Describe how you did it
1. Add `requiredWhenDestroyed` filed in flag which is necessary when destroying.
2. Use the suid value in the context to determine which way to execute destroy, if execute destroy command with target and action parameters, the suid value is unknown, otherwise is the experiment uid.

### Describe how to verify it
Create network and cpu experiments, then use two ways to destroy.

```
# create network experiment
blade c docker network delay --image-repo local --interface eth0 --local-port 80 --time 3000 --container-id a1fc0abc8a27

# destroy with target, action and necessary flags.
blade d docker network delay --container-id a1fc0abc8a27 --interface eth0

# create cpu experiment
blade c docker cpu fullload --container-id 1978a40b3e6d --blade-tar-file ../../build/image/blade/chaosblade-0.4.0.tar.gz --cpu-percent 60

# destroy with uid
blade d e505c6e5113b48f2

# receate it and destroy with target and action
blade d docker cpu fullload --container-id 1978a40b3e6d

```
