### PR TITLE
fix fail inject chaos to non-root container 

### DIFF
--- a/exec/executor_execin.go
+++ b/exec/executor_execin.go
@@ -109,7 +109,7 @@ func (r *RunCmdInContainerExecutorByCP) SetChannel(channel spec.Channel) {
 func (r *RunCmdInContainerExecutorByCP) DeployChaosBlade(ctx context.Context, containerId string,
 	srcFile, extractDirName string, override bool) error {
 	// check if the blade tool exists
-	output, err := r.Client.execContainer(containerId, fmt.Sprintf("[ -e %s ] && echo True || echo False", BladeBin))
+	output, err := r.Client.execContainerPrivileged(containerId, fmt.Sprintf("[ -e %s ] && echo True || echo False", BladeBin))
 	logrus.Debugf("output: %s, %v", output, err)
 	if err == nil && strings.Contains(output, "True") && !override {
 		return nil
@@ -122,6 +122,6 @@ func (r *RunCmdInContainerExecutorByCP) DeployChaosBlade(ctx context.Context, co
 	expectBladeDir := path.Join(DstChaosBladeDir, "chaosblade")
 	renameCmd := fmt.Sprintf("rm -rf %s && mv %s %s", expectBladeDir, dstBladeDir, expectBladeDir)
 	logrus.Debugf("renameCmd: %s", renameCmd)
-	_, err = r.Client.execContainer(containerId, renameCmd)
+	_, err = r.Client.execContainerPrivileged(containerId, renameCmd)
 	return err
 }


### PR DESCRIPTION
enable CopyUIDGID option when copy blade to container, otherwise blade file in container will belong to root and can't be execute with non root user && run command in container as root ensure chaosblade dir rename sucesss

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/chaosblade-io/chaosblade/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
 Fixes #8

